### PR TITLE
PR#1 feat: update .gitignore and README for quarkus-rca demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,26 @@
-kind/artifacts
+# ── Credentials and secrets — NEVER commit these ──────────────────────────
+quarkus-rca/llm.env
+quarkus-rca/causa-gcp-key.json
+
+# ── Demo artifacts (cloned repos + logs written at demo runtime) ───────────
+quarkus-rca/artifacts/
+kind/artifacts/
+*.log
+quarkus-rca-demo.log
+
+# ── macOS metadata ─────────────────────────────────────────────────────────
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# ── Editor / IDE ───────────────────────────────────────────────────────────
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# ── Bob IDE internal folders (not project config) ─────────────────────────
+# Keep: .bob/skills/ (workspace skills — committed intentionally)
+# Ignore: .bob/artifacts/ (generated HTML reports)
+.bob/artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 # ── Credentials and secrets — NEVER commit these ──────────────────────────
+# demo.sh reads exactly two secret files, both from quarkus-rca/:
+#   llm.env            — Vertex AI project ID, model, and alert cooldown
+#   causa-gcp-key.json — GCP service-account key used to create the
+#                        causa-gcp-credentials K8s Secret
+# No alternate paths or filenames are used by the scripts.
 quarkus-rca/llm.env
 quarkus-rca/causa-gcp-key.json
 

--- a/README.md
+++ b/README.md
@@ -1,61 +1,34 @@
 # causa-demos
 
-### This Repository contains the demos for CAUSA AI
+> Runnable demos that showcase **Causa AI** capabilities in Kubernetes environments.
 
-This repository provides runnable demos to showcase CAUSA AI capabilities in Kubernetes environments.
+---
 
-Currently, it contains a Kind-based demo that sets up a complete local Kubernetes environment and triggers a controlled failure scenario for RCA (Root Cause Analysis).
+## Available Demos
 
-### Available Demos
+### 1. Kind Demo
 
-#### 1. Kind Demo
+Provisions a local Kubernetes cluster using Kind and installs all required components to demonstrate Causa AI in action with a fully local, offline setup.
 
-The Kind demo provisions a local Kubernetes cluster using kind and installs all required components to demonstrate CAUSA AI in action.
+**What the demo does:**
 
-What the demo does:
-
-- Creates a kind Kubernetes cluster named causa
-- Installs CAUSA RCA Agent into the cluster
-- Installs Prometheus stack (via kube-prometheus)
-- Installs cAdvisor for container metrics
-- Deploys Ollama in-cluster and pulls the [phi3:mini](https://ollama.com/library/phi3) model to enable fully local, offline root cause analysis.
-- Deploys a Quarkus-based sample application that intentionally causes a Heap Out Of Memory (OOM) condition
+- Creates a Kind Kubernetes cluster named `causa`
+- Installs the Causa RCA Agent into the cluster
+- Installs Prometheus stack (via kube-prometheus) and cAdvisor for container metrics
+- Deploys Ollama in-cluster and pulls the [phi3:mini](https://ollama.com/library/phi3) model for fully local, offline root cause analysis
+- Deploys a Quarkus-based sample application that intentionally causes a heap Out Of Memory (OOM) condition
 - Deploys a load generator that gradually increases heap usage
-- Triggers a controlled OOM failure in the application
-- Allows CAUSA RCA Agent to analyze the failure and produce RCA logs
+- Triggers a controlled OOM failure and allows the Causa RCA Agent to produce RCA output
 
-#### Prerequisites
-
-Ensure the following tools are installed and available in your `$PATH` before running the demo:
+**Prerequisites:**
 
 ```text
-kind
-
-docker
-
-kubectl
-
-git
-
-jq
-
-python3
+kind      docker      kubectl      git      jq      python3
 ```
 
-##### Ollama Model Requirements: 
+> Ollama requires CPU-only execution with a minimum of 4 vCPUs (6+ recommended), at least 8 GB RAM (16 GB recommended), and approximately 2.5–3 GB free disk space for the phi3:mini model weights.
 
-- During deployment, the Ollama pod automatically pulls the required language model so it is available for inference at runtime. Currently, the following model is downloaded:
-
-    - **Model**: [phi3:mini](https://ollama.com/library/phi3) (Provided by Microsoft)
-    - Requires CPU-only execution with a minimum of 4 vCPUs (6+ vCPUs recommended).
-    - Requires at least 8 GB RAM (16 GB recommended for stability).
-    - ~ 2.5 GB to 3 GB free space is required for the model weights.
-    - *Note: CPU and memory requirements are inferred from the model size, as Ollama does not publish per-model resource limits.*
-
-
-
-
-#### How to run the demo
+**Quick start:**
 
 ```bash
 git clone https://github.com/causaai/causa-demos.git
@@ -63,26 +36,48 @@ cd causa-demos/kind
 ./demo.sh
 ```
 
-#### Steps After the Demo Script Completes
-
-Once the Kind demo script finishes running and reports that the Heap OOM has been reached, follow these steps to observe CAUSA AI in action:
-
-- Inspect CAUSA RCA Agent logs
+**Cleanup:**
 
 ```bash
-kubectl logs -f <rca-agent-pod>
+# Remove all resources
+./demo.sh -t
+
+# Remove resources and artifacts directory
+./demo.sh -t -f
 ```
 
-- Clean up resources when done
+---
 
-Once you are done with the demo, proceed to clean it up with `-t` option
+### 2. Quarkus RCA Demo
+
+An end-to-end demo that deploys a **quarkus-perf** workload engineered to OOMKill, installs the full Causa RCA stack (Causa Backend, Causa MCP, Kubernetes MCP Server, PostgreSQL, Prometheus), configures LLM credentials, and wires up **Bob IDE** for AI-powered root cause analysis.
+
+**What the demo does:**
+
+- Provisions a Kind cluster and deploys the full Causa RCA stack via the [Quarkus RCA installer](https://github.com/gulati-aakriti/installer)
+- Deploys **quarkus-perf** with chaos flags enabled (`CHAOS_MEMORY_CACHE_ENABLED=true`) — the workload leaks 192 KB of heap per transaction with no eviction, OOMKilling in approximately 3–5 minutes under load
+- Pushes LLM credentials (Vertex AI / Claude) and alert cooldown to Causa Backend
+- Registers the Causa MCP server in `~/.bob/settings/mcp.json` and installs the `causa-rca` skill into Bob IDE
+- Prints a ready-to-paste Bob IDE prompt for triggering RCA
+
+**Prerequisites:**
+
+```text
+kind      kubectl     docker (or podman)     git     python3
+```
+
+**Quick start:**
+
+```bash
+git clone https://github.com/causaai/causa-demos.git
+cd causa-demos/quarkus-rca
+./demo.sh
+```
+
+See **[quarkus-rca/docs/SETUP.md](quarkus-rca/docs/SETUP.md)** for full prerequisites, LLM credential setup, CLI options, image overrides, Alertmanager configuration, and troubleshooting.
+
+**Cleanup:**
 
 ```bash
 ./demo.sh -t
-```
-
-To also remove the artifacts directory during cleanup, use `-f` with `-t`:
-
-```bash
-./demo.sh -f -t
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ An end-to-end demo that deploys a **quarkus-perf** workload engineered to OOMKil
 **What the demo does:**
 
 - Provisions a Kind cluster and deploys the full Causa RCA stack via the [Quarkus RCA installer](https://github.com/gulati-aakriti/installer) _(personal fork, work in progress — the installer URL can be overridden via `--installer-url` if an official repo is available)_
-- Deploys **quarkus-perf** with chaos flags enabled (`CHAOS_MEMORY_CACHE_ENABLED=true`) — the workload leaks 192 KB of heap per transaction with no eviction, OOMKilling in approximately 3–5 minutes under load
+- Deploys **quarkus-perf** with chaos flags enabled (`CHAOS_MEMORY_CACHE_ENABLED=true`) — the workload leaks 192 KB of heap per transaction with no eviction, resulting in the workload being OOM-killed in approximately 3–5 minutes under load
 - Pushes LLM credentials (Vertex AI / Claude) and alert cooldown to Causa Backend
 - Registers the Causa MCP server in `~/.bob/settings/mcp.json` and installs the `causa-rca` skill into Bob IDE
 - Prints a ready-to-paste Bob IDE prompt for triggering RCA

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## Available Demos
 
+The two demos are **independent** — each provisions its own Kind cluster and can be run in any order or in isolation. You do not need to run the Kind demo before the Quarkus RCA demo.
+
 ### 1. Kind Demo
 
 Provisions a local Kubernetes cluster using Kind and installs all required components to demonstrate Causa AI in action with a fully local, offline setup.
@@ -54,7 +56,7 @@ An end-to-end demo that deploys a **quarkus-perf** workload engineered to OOMKil
 
 **What the demo does:**
 
-- Provisions a Kind cluster and deploys the full Causa RCA stack via the [Quarkus RCA installer](https://github.com/gulati-aakriti/installer)
+- Provisions a Kind cluster and deploys the full Causa RCA stack via the [Quarkus RCA installer](https://github.com/gulati-aakriti/installer) _(personal fork, work in progress — the installer URL can be overridden via `--installer-url` if an official repo is available)_
 - Deploys **quarkus-perf** with chaos flags enabled (`CHAOS_MEMORY_CACHE_ENABLED=true`) — the workload leaks 192 KB of heap per transaction with no eviction, OOMKilling in approximately 3–5 minutes under load
 - Pushes LLM credentials (Vertex AI / Claude) and alert cooldown to Causa Backend
 - Registers the Causa MCP server in `~/.bob/settings/mcp.json` and installs the `causa-rca` skill into Bob IDE


### PR DESCRIPTION
.gitignore previously had a single entry (kind/artifacts). This PR expands it with five clearly labelled sections: credentials and secrets that must never be committed (llm.env, causa-gcp-key.json), demo runtime artifacts and log files, macOS metadata, common editor/IDE artefacts, and Bob IDE internal folders — while explicitly keeping .bob/skills/ committed as a workspace skill.

README.md is rewritten from a loose prose description to a structured document: a concise intro, a formatted "Available Demos" section with a quick-start block for the Kind demo, properly formatted prerequisite table, Ollama resource requirements, and cleanup instructions. No functional code is changed.

## Summary by Sourcery

Document and organize the available Kubernetes demos while tightening repository hygiene for local runtime artifacts and secrets.

New Features:
- Introduce a dedicated Quarkus RCA demo section describing an end-to-end OOMKill RCA workflow integrated with Bob IDE.
- Add structured quick-start and cleanup flows for both the Kind and Quarkus RCA demos.

Enhancements:
- Restructure README into a clearer, task-focused format with prerequisites, resource notes, and references to detailed setup docs.
- Clarify Ollama model resource requirements and local, offline RCA capabilities in the Kind demo documentation.

Documentation:
- Rewrite README to provide a structured overview of available demos, usage, prerequisites, cleanup steps, and links to deeper documentation.

Chores:
- Expand .gitignore to cover secrets, runtime artifacts, OS/editor metadata, and Bob IDE folders while keeping workspace skills versioned.