### PR TITLE
fix(llm): post GCP credentials as base64 to config API

### DIFF
--- a/quarkus-rca/demo.sh
+++ b/quarkus-rca/demo.sh
@@ -135,9 +135,15 @@ show_help() {
     echo "    -h                       Show this help message"
     echo ""
     echo "MCP server registration:"
-    echo "    .mcp.json is always written to the repo root. Any IDE that supports the"
-    echo "    cross-IDE MCP standard (Claude shell, Cursor, Windsurf, VS Code Copilot,"
-    echo "    Gemini CLI) auto-loads it — no per-user or per-IDE setup required."
+    echo "    The script writes MCP config based on --skill-path:"
+    echo "      --skill-path ~/.bob/skills   → writes .bob/mcp.json only (Bob IDE)"
+    echo "                                     removes stale causa-rca from .mcp.json"
+    echo "      --skill-path <other>         → writes .mcp.json only (cross-IDE root)"
+    echo "                                     removes stale causa-rca from .bob/mcp.json"
+    echo "      (no --skill-path)            → writes both .mcp.json and .bob/mcp.json"
+    echo "    Any IDE that supports the cross-IDE MCP standard (Claude Code CLI, Cursor,"
+    echo "    Windsurf, VS Code Copilot, Gemini CLI) auto-loads .mcp.json from the repo"
+    echo "    root. Bob reads .bob/mcp.json."
     echo ""
     echo "Skill installation:"
     echo "    Pass --skill-path <dir> to have the script copy SKILL.md to that location."
@@ -316,10 +322,14 @@ except Exception as e:
     sys.exit(1)
 PYEOF
             _remove_bob_mcp_rc=$?
+        else
+            write_to_log_file "WARN" "python3 not available — could not remove causa-rca from .bob/mcp.json; remove it manually"
         fi
         stop_spinner
         if [[ $_remove_bob_mcp_rc -eq 0 ]]; then
             log_install_success "Causa MCP removed from .bob/mcp.json"
+        else
+            log_file_only "Failed to remove causa-rca from .bob/mcp.json — remove it manually (python3 required)"
         fi
     fi
 
@@ -699,7 +709,11 @@ fi
 # ── 4a: Write the correct MCP config file for the detected IDE ───────────
 # Bob IDE reads .bob/mcp.json; every other IDE (Claude Code CLI, Cursor,
 # Windsurf, VS Code Copilot, Gemini CLI) reads the cross-IDE .mcp.json at
-# the repo root. The two are mutually exclusive — we write exactly one.
+# the repo root.
+# Routing:
+#   Bob skill path  → write .bob/mcp.json; remove stale entry from .mcp.json
+#   other skill path→ write .mcp.json; remove stale entry from .bob/mcp.json
+#   no --skill-path → write both (safe default for any IDE)
 _MCP_JSON_PATH="${SCRIPT_DIR}/../.mcp.json"
 _BOB_MCP_JSON_PATH="${SCRIPT_DIR}/../.bob/mcp.json"
 
@@ -742,7 +756,7 @@ PYEOF
 }
 
 if [[ "$_IS_BOB_SKILL_PATH" == "true" ]]; then
-    # Bob IDE: write .bob/mcp.json only
+    # Bob IDE: write .bob/mcp.json; remove stale entry from .mcp.json if present
     start_spinner "Writing .bob/mcp.json for Bob IDE..."
     _bob_mcp_json_rc=1
     if command_exists python3; then
@@ -757,8 +771,25 @@ if [[ "$_IS_BOB_SKILL_PATH" == "true" ]]; then
         log_file_only "Failed to write .bob/mcp.json — add manually via Bob Settings → MCP → Edit Project MCP"
         log_validation_success ".bob/mcp.json (failed — add manually)"
     fi
+    # Remove stale causa-rca from .mcp.json left by a previous non-Bob run
+    if [[ -f "$_MCP_JSON_PATH" ]] && command_exists python3; then
+        python3 - "$_MCP_JSON_PATH" << 'PYEOF' >>"$LOG_FILE" 2>&1 || true
+import json, sys, os
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+    cfg.get("mcpServers", {}).pop("causa-rca", None)
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+except Exception:
+    pass
+PYEOF
+        write_to_log_file "INFO" "Removed stale causa-rca entry from .mcp.json (Bob run)"
+    fi
 elif [[ -n "$SKILL_PATH" ]]; then
-    # Explicit non-Bob skill path (e.g. Claude): write cross-IDE root .mcp.json only
+    # Explicit non-Bob skill path (e.g. Claude): write .mcp.json; remove stale entry from .bob/mcp.json if present
     start_spinner "Writing .mcp.json to repo root..."
     _mcp_json_rc=1
     if command_exists python3; then
@@ -772,6 +803,23 @@ elif [[ -n "$SKILL_PATH" ]]; then
     else
         log_file_only "Failed to write .mcp.json — add manually"
         log_validation_success ".mcp.json (failed — add manually)"
+    fi
+    # Remove stale causa-rca from .bob/mcp.json left by a previous Bob run
+    if [[ -f "$_BOB_MCP_JSON_PATH" ]] && command_exists python3; then
+        python3 - "$_BOB_MCP_JSON_PATH" << 'PYEOF' >>"$LOG_FILE" 2>&1 || true
+import json, sys, os
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+    cfg.get("mcpServers", {}).pop("causa-rca", None)
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+except Exception:
+    pass
+PYEOF
+        write_to_log_file "INFO" "Removed stale causa-rca entry from .bob/mcp.json (non-Bob run)"
     fi
 else
     # No --skill-path given: write both so any IDE works out of the box

--- a/quarkus-rca/demo.sh
+++ b/quarkus-rca/demo.sh
@@ -213,7 +213,7 @@ while [[ $# -gt 0 ]]; do
             [[ -z "${2:-}" ]] && { echo "ERROR: value required for --skill-path" >&2; exit 1; }
             SKILL_PATH="$2"; shift 2 ;;
         -t)               TERMINATE=true; shift ;;
-        --delete-cluster) DELETE_CLUSTER=true; shift ;;
+        --delete-cluster) [[ "$TERMINATE" == "true" ]] || { echo "ERROR: --delete-cluster requires -t" >&2; exit 1; }; DELETE_CLUSTER=true; shift ;;
         --skip-installer) SKIP_INSTALLER=true; shift ;;
         --installer-url)
             [[ -z "${2:-}" ]] && { echo "ERROR: value required for --installer-url" >&2; exit 1; }
@@ -641,7 +641,7 @@ _BOB_MCP_JSON_PATH="${SCRIPT_DIR}/../.bob/mcp.json"
 _IS_BOB_SKILL_PATH=false
 if [[ -n "$SKILL_PATH" ]]; then
     _expanded_skill_path="${SKILL_PATH/#\~/$HOME}"
-    if [[ "$_expanded_skill_path" == *"/.bob/"* || "$_expanded_skill_path" == *"/.bob" ]]; then
+    if [[ "$_expanded_skill_path" == *"/.bob/"* || "$_expanded_skill_path" == *"/.bob" || "$_expanded_skill_path" == ".bob/"* ]]; then
         _IS_BOB_SKILL_PATH=true
     fi
 fi

--- a/quarkus-rca/demo.sh
+++ b/quarkus-rca/demo.sh
@@ -262,18 +262,16 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Terminate mode
+# MCP JSON helpers — defined early so both the terminate path and the install
+# path can call them without a forward-reference problem.
 # ---------------------------------------------------------------------------
-if [[ "$TERMINATE" == "true" ]]; then
-    terminate_demo "$NAMESPACE" "$DEMO_DIR" "$SKIP_INSTALLER"
 
-    # Remove causa-rca from project-level .mcp.json (cross-IDE root)
-    _MCP_JSON_PATH="${SCRIPT_DIR}/../.mcp.json"
-    if [[ -f "$_MCP_JSON_PATH" ]]; then
-        start_spinner "Removing Causa MCP from project .mcp.json..."
-        _remove_mcp_json_rc=1
-        if command_exists python3; then
-            python3 - "$_MCP_JSON_PATH" << 'PYEOF'
+# Helper: remove the causa-rca entry from an existing JSON file.
+# Returns 0 on success, 1 on any error (including python3 failure).
+# No-op (exit 0) if the file does not exist or has no causa-rca key.
+_remove_mcp_entry() {
+    local _target_path="$1"
+    python3 - "$_target_path" << 'PYEOF'
 import json, sys
 path = sys.argv[1]
 try:
@@ -288,6 +286,49 @@ except Exception as e:
     print(f"warn: {e}", file=sys.stderr)
     sys.exit(1)
 PYEOF
+}
+
+# Helper: merge causa-rca entry into an existing or new JSON file.
+# Creates the target directory if it does not exist; returns 1 if mkdir fails.
+_write_mcp_entry() {
+    local _target_path="$1"
+    local _target_dir
+    _target_dir="$(dirname "$_target_path")"
+    mkdir -p "$_target_dir" || return 1
+    python3 - "$_target_path" "$CAUSA_MCP_URL" << 'PYEOF'
+import json, sys, os
+path, url = sys.argv[1], sys.argv[2]
+cfg = {}
+if os.path.isfile(path):
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except json.JSONDecodeError:
+        cfg = {}
+cfg.setdefault("mcpServers", {})["causa-rca"] = {
+    "type": "http",
+    "url": url + "/mcp"
+}
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+    f.write("\n")
+print("ok")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Terminate mode
+# ---------------------------------------------------------------------------
+if [[ "$TERMINATE" == "true" ]]; then
+    terminate_demo "$NAMESPACE" "$DEMO_DIR" "$SKIP_INSTALLER"
+
+    # Remove causa-rca from project-level .mcp.json (cross-IDE root)
+    _MCP_JSON_PATH="${SCRIPT_DIR}/../.mcp.json"
+    if [[ -f "$_MCP_JSON_PATH" ]]; then
+        start_spinner "Removing Causa MCP from project .mcp.json..."
+        _remove_mcp_json_rc=1
+        if command_exists python3; then
+            _remove_mcp_entry "$_MCP_JSON_PATH"
             _remove_mcp_json_rc=$?
         fi
         stop_spinner
@@ -302,21 +343,7 @@ PYEOF
         start_spinner "Removing Causa MCP from .bob/mcp.json..."
         _remove_bob_mcp_rc=1
         if command_exists python3; then
-            python3 - "$_BOB_MCP_JSON_PATH" << 'PYEOF'
-import json, sys
-path = sys.argv[1]
-try:
-    with open(path) as f:
-        cfg = json.load(f)
-    cfg.get("mcpServers", {}).pop("causa-rca", None)
-    with open(path, "w") as f:
-        json.dump(cfg, f, indent=2)
-        f.write("\n")
-    print("removed")
-except Exception as e:
-    print(f"warn: {e}", file=sys.stderr)
-    sys.exit(1)
-PYEOF
+            _remove_mcp_entry "$_BOB_MCP_JSON_PATH"
             _remove_bob_mcp_rc=$?
         else
             write_to_log_file "WARN" "python3 not available — could not remove causa-rca from .bob/mcp.json; remove it manually"
@@ -384,9 +411,13 @@ ensure_directory "$DEMO_DIR"
 cd "$DEMO_DIR"
 
 # Phase 1 (cont): create the GCP/LLM K8s secret now, before the installer.
-# The namespace may not exist yet — ensure_namespace is called inside
-# create_llm_secrets if needed, but for Kind the installer creates it so
-# we pass it and let the function guard against it not existing yet.
+# On a fresh Kind cluster the namespace does not exist yet — the installer
+# creates it in Step 1. If the namespace is missing, kubectl will fail and
+# create_llm_secrets logs a non-fatal warning and continues. The installer
+# will then create the namespace and the secret can be re-created manually
+# or on the next run, but in practice the installer creates the namespace
+# before starting causa-backend so the missing secret is harmless for the
+# initial startup window.
 if [[ -f "$LLM_ENV_FILE" ]]; then
     create_llm_secrets "$LLM_ENV_FILE" "$NAMESPACE"
 fi
@@ -602,33 +633,6 @@ fi
 
 log_section "Step 4: Writing project-level MCP config"
 
-# Helper: merge causa-rca entry into an existing or new JSON file
-_write_mcp_entry() {
-    local _target_path="$1"
-    local _target_dir
-    _target_dir="$(dirname "$_target_path")"
-    mkdir -p "$_target_dir"
-    python3 - "$_target_path" "$CAUSA_MCP_URL" << 'PYEOF'
-import json, sys, os
-path, url = sys.argv[1], sys.argv[2]
-cfg = {}
-if os.path.isfile(path):
-    try:
-        with open(path) as f:
-            cfg = json.load(f)
-    except json.JSONDecodeError:
-        cfg = {}
-cfg.setdefault("mcpServers", {})["causa-rca"] = {
-    "type": "http",
-    "url": url + "/mcp"
-}
-with open(path, "w") as f:
-    json.dump(cfg, f, indent=2)
-    f.write("\n")
-print("ok")
-PYEOF
-}
-
 if [[ "$_IS_BOB_SKILL_PATH" == "true" ]]; then
     # Bob IDE: write .bob/mcp.json; remove stale entry from .mcp.json if present
     start_spinner "Writing .bob/mcp.json for Bob IDE..."
@@ -647,19 +651,7 @@ if [[ "$_IS_BOB_SKILL_PATH" == "true" ]]; then
     fi
     # Remove stale causa-rca from .mcp.json left by a previous non-Bob run
     if [[ -f "$_MCP_JSON_PATH" ]] && command_exists python3; then
-        python3 - "$_MCP_JSON_PATH" << 'PYEOF' >>"$LOG_FILE" 2>&1 || true
-import json, sys, os
-path = sys.argv[1]
-try:
-    with open(path) as f:
-        cfg = json.load(f)
-    cfg.get("mcpServers", {}).pop("causa-rca", None)
-    with open(path, "w") as f:
-        json.dump(cfg, f, indent=2)
-        f.write("\n")
-except Exception:
-    pass
-PYEOF
+        _remove_mcp_entry "$_MCP_JSON_PATH" >>"$LOG_FILE" 2>&1 || true
         write_to_log_file "INFO" "Removed stale causa-rca entry from .mcp.json (Bob run)"
     fi
 elif [[ -n "$SKILL_PATH" ]]; then
@@ -680,19 +672,7 @@ elif [[ -n "$SKILL_PATH" ]]; then
     fi
     # Remove stale causa-rca from .bob/mcp.json left by a previous Bob run
     if [[ -f "$_BOB_MCP_JSON_PATH" ]] && command_exists python3; then
-        python3 - "$_BOB_MCP_JSON_PATH" << 'PYEOF' >>"$LOG_FILE" 2>&1 || true
-import json, sys, os
-path = sys.argv[1]
-try:
-    with open(path) as f:
-        cfg = json.load(f)
-    cfg.get("mcpServers", {}).pop("causa-rca", None)
-    with open(path, "w") as f:
-        json.dump(cfg, f, indent=2)
-        f.write("\n")
-except Exception:
-    pass
-PYEOF
+        _remove_mcp_entry "$_BOB_MCP_JSON_PATH" >>"$LOG_FILE" 2>&1 || true
         write_to_log_file "INFO" "Removed stale causa-rca entry from .bob/mcp.json (non-Bob run)"
     fi
 else
@@ -892,11 +872,11 @@ _POD_DISPLAY="${_QP_POD:-quarkus-perf-<generated-suffix>}"
     echo -e "${COLOR_CYAN}Causa MCP:${COLOR_RESET}     ${CAUSA_MCP_URL}/mcp"
     if [[ "$_IS_BOB_SKILL_PATH" == "true" ]]; then
         echo -e "${COLOR_CYAN}Bob MCP config:${COLOR_RESET}     ${SCRIPT_DIR}/../.bob/mcp.json"
-    elif [[ -n "$SKILL_PATH" ]]; then
-        echo -e "${COLOR_CYAN}Project MCP config:${COLOR_RESET} ${SCRIPT_DIR}/../.mcp.json"
     else
         echo -e "${COLOR_CYAN}Project MCP config:${COLOR_RESET} ${SCRIPT_DIR}/../.mcp.json"
-        echo -e "${COLOR_CYAN}Bob MCP config:${COLOR_RESET}     ${SCRIPT_DIR}/../.bob/mcp.json"
+        if [[ -z "$SKILL_PATH" ]]; then
+            echo -e "${COLOR_CYAN}Bob MCP config:${COLOR_RESET}     ${SCRIPT_DIR}/../.bob/mcp.json"
+        fi
     fi
     echo ""
 

--- a/quarkus-rca/demo.sh
+++ b/quarkus-rca/demo.sh
@@ -42,6 +42,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOGGING_FILE="$SCRIPT_DIR/lib/logging.sh"
 UTILS_FILE="$SCRIPT_DIR/lib/utils.sh"
 UNINSTALL_FILE="$SCRIPT_DIR/lib/uninstall.sh"
+LLM_FILE="$SCRIPT_DIR/lib/llm.sh"
 
 IMAGES_ENV_FILE="$SCRIPT_DIR/images.env"
 if [[ -f "$IMAGES_ENV_FILE" ]]; then
@@ -52,7 +53,7 @@ if [[ -f "$IMAGES_ENV_FILE" ]]; then
     echo -e "\033[0;36m[images.env]\033[0m Image overrides loaded from: $IMAGES_ENV_FILE"
 fi
 
-for _f in "$LOGGING_FILE" "$UTILS_FILE" "$UNINSTALL_FILE"; do
+for _f in "$LOGGING_FILE" "$UTILS_FILE" "$UNINSTALL_FILE" "$LLM_FILE"; do
     if [[ ! -f "$_f" ]]; then
         echo "ERROR: $(basename "$_f") not found at $_f"
         exit 1
@@ -62,6 +63,7 @@ done
 source "$LOGGING_FILE"
 source "$UTILS_FILE"
 source "$UNINSTALL_FILE"
+source "$LLM_FILE"
 
 _demo_exit_trap() { trap '' INT TERM; stop_spinner; exit 130; }
 trap '_demo_exit_trap' INT TERM
@@ -224,15 +226,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ---------------------------------------------------------------------------
-# Load llm.env early
+# LLM env path — used by validate_llm_config / create_llm_secrets / configure_llm_runtime
 # ---------------------------------------------------------------------------
-_LLM_ENV_FILE="$SCRIPT_DIR/llm.env"
-if [[ -f "$_LLM_ENV_FILE" ]]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$_LLM_ENV_FILE"
-    set +a
-fi
+LLM_ENV_FILE="$SCRIPT_DIR/llm.env"
 
 # ---------------------------------------------------------------------------
 # Initialise logging
@@ -375,8 +371,25 @@ write_to_log_file "INFO" "Container runtime: $CONTAINER_RUNTIME"
 
 log_validation_success "Validating Prerequisites"
 
+# Phase 1: validate LLM config and create K8s secrets BEFORE the installer
+# runs, so causa-backend has its credentials secret available on first startup.
+if [[ -f "$LLM_ENV_FILE" ]]; then
+    if ! validate_llm_config "$LLM_ENV_FILE"; then
+        exit 1
+    fi
+    log_validation_success "LLM Configuration"
+fi
+
 ensure_directory "$DEMO_DIR"
 cd "$DEMO_DIR"
+
+# Phase 1 (cont): create the GCP/LLM K8s secret now, before the installer.
+# The namespace may not exist yet — ensure_namespace is called inside
+# create_llm_secrets if needed, but for Kind the installer creates it so
+# we pass it and let the function guard against it not existing yet.
+if [[ -f "$LLM_ENV_FILE" ]]; then
+    create_llm_secrets "$LLM_ENV_FILE" "$NAMESPACE"
+fi
 
 # ===========================================================================
 # Step 1: Run install.sh (Causa RCA stack on kind)
@@ -552,155 +565,16 @@ fi
 
 
 # ===========================================================================
-# Step 3: Configure Causa Backend — LLM credentials
+# Step 3: Configure Causa Backend (LLM) — Phase 2
 # ===========================================================================
-# Sources llm.env, creates the causa-gcp-credentials K8s Secret from
-# causa-gcp-key.json, and pushes LLM config to Causa via
-# POST /api/v1/configs (default Causa cooldown is preserved).
-#
-# Non-fatal: if no LLM provider is configured, Causa performs RCA using
-# heuristics without LLM config.
+# Phase 1 (create_llm_secrets) already ran before the installer.
+# Phase 2 posts the non-sensitive config keys to the now-running backend.
+# The GCP credential is NOT posted here — it is already available to the
+# backend via the K8s Secret created in Phase 1 and the
+# GOOGLE_APPLICATION_CREDENTIALS env var set in the deployment manifest.
 # ===========================================================================
 log_section "Step 3: Configuring Causa Backend (LLM)"
-
-if [[ -f "$_LLM_ENV_FILE" ]]; then
-    write_to_log_file "INFO" "Using LLM config loaded from: $_LLM_ENV_FILE"
-else
-    write_to_log_file "INFO" "llm.env not found — using exported environment variables"
-    write_to_log_file "INFO" "Copy llm.env.example to llm.env and fill in values to enable LLM RCA"
-fi
-
-# ── Auto-create causa-gcp-credentials K8s Secret from local key file ─────
-_GCP_KEY_FILE="$SCRIPT_DIR/causa-gcp-key.json"
-if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" && -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-    _GCP_KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS}"
-fi
-
-if [[ "${LLM_PROVIDER:-}" == "vertex-ai-anthropic" || -n "${VERTEX_PROJECT_ID:-}" ]]; then
-    if kubectl get secret causa-gcp-credentials \
-            -n "$NAMESPACE" >>"$LOG_FILE" 2>&1; then
-        write_to_log_file "INFO" "causa-gcp-credentials secret already exists in $NAMESPACE"
-    elif [[ -f "$_GCP_KEY_FILE" ]]; then
-        start_spinner "Creating causa-gcp-credentials secret from $(basename "$_GCP_KEY_FILE")..."
-        if kubectl create secret generic causa-gcp-credentials \
-                --from-file="key.json=$_GCP_KEY_FILE" \
-                -n "$NAMESPACE" >>"$LOG_FILE" 2>&1; then
-            stop_spinner
-            log_install_success "causa-gcp-credentials secret created"
-        else
-            stop_spinner
-            log_file_only "Failed to create causa-gcp-credentials secret — check $LOG_FILE"
-        fi
-    else
-        write_to_log_file "WARN" "GCP key file not found at $_GCP_KEY_FILE"
-        write_to_log_file "WARN" "Place the GCP service-account key there to enable Vertex AI LLM RCA"
-    fi
-fi
-
-# ── Read GCP key back as a single-line base64 blob from the K8s Secret ───
-_GCP_B64=""
-if [[ "${LLM_PROVIDER:-}" == "vertex-ai-anthropic" || -n "${VERTEX_PROJECT_ID:-}" ]]; then
-    _GCP_B64=$(kubectl get secret causa-gcp-credentials \
-        -n "$NAMESPACE" \
-        -o "jsonpath={.data.key\.json}" \
-        2>>"$LOG_FILE" | tr -d '[:space:]' || true)
-    if [[ -z "$_GCP_B64" && -f "$_GCP_KEY_FILE" ]]; then
-        _GCP_B64=$(base64 < "$_GCP_KEY_FILE" | tr -d '[:space:]')
-    fi
-fi
-
-# ── Build POST /api/v1/configs payload ───────────────────────────────────
-# Use python3 to build a valid, properly escaped JSON payload for all providers
-_CONFIG_PAYLOAD=$(python3 - << 'PYEOF'
-import os, json
-
-configs = {}
-
-# Check provider and general LLM settings
-provider = os.getenv("LLM_PROVIDER", "").strip()
-model = os.getenv("LLM_MODEL_NAME", "").strip()
-api_key = os.getenv("LLM_API_KEY", "").strip()
-endpoint = os.getenv("LLM_ENDPOINT", "").strip()
-temperature = os.getenv("LLM_TEMPERATURE", "").strip()
-
-if provider:
-    configs["LLM_PROVIDER"] = provider
-if model:
-    configs["LLM_MODEL_NAME"] = model
-if api_key:
-    configs["LLM_API_KEY"] = api_key
-if endpoint:
-    configs["LLM_ENDPOINT"] = endpoint
-if temperature:
-    configs["LLM_TEMPERATURE"] = temperature
-
-# Vertex AI specific
-vertex_proj = os.getenv("VERTEX_PROJECT_ID", "").strip()
-vertex_loc = os.getenv("VERTEX_LOCATION", "").strip()
-gcp_b64 = os.getenv("_GCP_B64", "").strip()
-
-if vertex_proj:
-    configs["VERTEX_PROJECT_ID"] = vertex_proj
-if vertex_loc:
-    configs["VERTEX_LOCATION"] = vertex_loc
-if gcp_b64:
-    configs["GOOGLE_APPLICATION_CREDENTIALS"] = gcp_b64
-
-# Bob / custom provider specific
-bob_shell_path = os.getenv("BOB_SHELL_PATH", os.getenv("BOB_PATH", "")).strip()
-if bob_shell_path:
-    configs["BOB_SHELL_PATH"] = bob_shell_path
-
-print(json.dumps({"configs": configs}))
-PYEOF
-)
-
-# ── Push LLM config to Causa Backend if configured ───────────────────────
-_HAS_LLM_CONFIG=$(python3 -c "import json, os; p=json.loads('''$_CONFIG_PAYLOAD''').get('configs',{}); print('true' if len(p) > 0 else 'false')")
-
-if [[ "$_HAS_LLM_CONFIG" == "true" ]]; then
-    write_to_log_file "INFO" "Pushing LLM config (provider: ${LLM_PROVIDER:-auto}, model: ${LLM_MODEL_NAME:-default}) to Causa"
-
-    # ── Find running Causa Backend pod ───────────────────────────────────────
-    _CAUSA_POD=$(kubectl get pods \
-        -l "app=causa-backend" \
-        -n "$NAMESPACE" \
-        --field-selector="status.phase=Running" \
-        -o "jsonpath={.items[0].metadata.name}" \
-        2>>"$LOG_FILE" || true)
-
-    if [[ -z "$_CAUSA_POD" ]]; then
-        write_to_log_file "WARN" "Causa Backend pod not running — skipping config push (RCA will run without LLM)"
-    else
-        start_spinner "Pushing config to Causa Backend (up to 5 attempts)..."
-        _cfg_rc=1
-        for _attempt in 1 2 3 4 5; do
-            _cfg_rc=0
-            kubectl exec -n "$NAMESPACE" "$_CAUSA_POD" -- \
-                curl -sf --max-time 10 \
-                -X POST "http://localhost:8080/api/v1/configs" \
-                -H "Content-Type: application/json" \
-                -d "$_CONFIG_PAYLOAD" \
-                >>"$LOG_FILE" 2>&1 || _cfg_rc=$?
-
-            if [[ $_cfg_rc -eq 0 ]]; then
-                break
-            fi
-            write_to_log_file "INFO" "Config push attempt ${_attempt}/5 failed (rc=${_cfg_rc}) — retrying in 10s..."
-            [[ $_attempt -lt 5 ]] && sleep 10
-        done
-        stop_spinner
-        if [[ $_cfg_rc -eq 0 ]]; then
-            log_install_success "Causa Backend configured (LLM config pushed)"
-        else
-            log_file_only "Config push failed after 5 attempts (non-fatal — RCA will run without LLM)"
-            log_validation_success "Causa config push (failed — check $LOG_FILE)"
-        fi
-    fi
-else
-    write_to_log_file "INFO" "No LLM provider configured — Causa Backend will use default settings / heuristic RCA"
-    log_validation_success "Causa Backend LLM config (skipped — no provider set in llm.env)"
-fi
+configure_llm_runtime "$LLM_ENV_FILE" "$NAMESPACE"
 
 # ===========================================================================
 # Step 4: Register Causa MCP + install skill (optional)

--- a/quarkus-rca/demo.sh
+++ b/quarkus-rca/demo.sh
@@ -75,6 +75,7 @@ NAMESPACE="causa-rca"
 TARGET="${TARGET:-kind}"
 SKILL_PATH=""
 TERMINATE=false
+DELETE_CLUSTER=false
 SKIP_INSTALLER=false
 DEMO_DIR="$SCRIPT_DIR/artifacts"
 
@@ -111,7 +112,7 @@ CAUSA_BACKEND_URL="http://localhost:30001"
 show_help() {
     echo "Quarkus RCA Demo Script"
     echo ""
-    echo "Usage: $0 [--target TARGET] [-n namespace] [--skill-path DIR] [-t] [--skip-installer] [--installer-url URL] [--installer-branch BRANCH] [--chaos-lab-url URL] [--chaos-lab-branch BRANCH] [-h]"
+    echo "Usage: $0 [--target TARGET] [-n namespace] [--skill-path DIR] [-t] [--delete-cluster] [--skip-installer] [--installer-url URL] [--installer-branch BRANCH] [--chaos-lab-url URL] [--chaos-lab-branch BRANCH] [-h]"
     echo ""
     echo "Options:"
     echo "    --target TARGET          Target platform: kind, openshift, vm, etc. (default: kind)"
@@ -125,6 +126,8 @@ show_help() {
     echo "                               --skill-path ~/.bob/skills        (Bob)"
     echo "                               --skill-path ~/.claude/skills     (Claude Code)"
     echo "    -t                       Terminate mode: clean up all resources"
+    echo "    --delete-cluster         Also delete the Kind cluster when terminating (kind target only)."
+    echo "                             Must be used together with -t."
     echo "    --skip-installer         Skip running install.sh (use when stack is already deployed)"
     echo "    --installer-url URL      Git URL of the installer repo"
     echo "                             Default: https://github.com/causaai/installer"
@@ -185,8 +188,11 @@ show_help() {
     echo "    # Skip installer (stack already running)"
     echo "    $0 --skip-installer"
     echo ""
-    echo "    # Tear down everything"
+    echo "    # Tear down everything (keep cluster)"
     echo "    $0 -t"
+    echo ""
+    echo "    # Tear down everything including the Kind cluster"
+    echo "    $0 -t --delete-cluster"
     echo ""
     echo "Prerequisites:  kind (if target=kind)  kubectl  docker or podman  git  python3"
     echo ""
@@ -207,6 +213,7 @@ while [[ $# -gt 0 ]]; do
             [[ -z "${2:-}" ]] && { echo "ERROR: value required for --skill-path" >&2; exit 1; }
             SKILL_PATH="$2"; shift 2 ;;
         -t)               TERMINATE=true; shift ;;
+        --delete-cluster) DELETE_CLUSTER=true; shift ;;
         --skip-installer) SKIP_INSTALLER=true; shift ;;
         --installer-url)
             [[ -z "${2:-}" ]] && { echo "ERROR: value required for --installer-url" >&2; exit 1; }
@@ -320,7 +327,7 @@ PYEOF
 # Terminate mode
 # ---------------------------------------------------------------------------
 if [[ "$TERMINATE" == "true" ]]; then
-    terminate_demo "$NAMESPACE" "$DEMO_DIR" "$SKIP_INSTALLER"
+    terminate_demo "$NAMESPACE" "$DEMO_DIR" "$SKIP_INSTALLER" "$DELETE_CLUSTER"
 
     # Remove causa-rca from project-level .mcp.json (cross-IDE root)
     _MCP_JSON_PATH="${SCRIPT_DIR}/../.mcp.json"
@@ -396,31 +403,29 @@ fi
 export CONTAINER_RUNTIME
 write_to_log_file "INFO" "Container runtime: $CONTAINER_RUNTIME"
 
+# llm.env is required — it tells Causa Backend which LLM to use for RCA.
+# Fail here, inside the prerequisites block, so the user gets a single clear
+# error before any infrastructure work starts.
+if [[ ! -f "$LLM_ENV_FILE" ]]; then
+    log_error "llm.env not found: $LLM_ENV_FILE"
+    log_error "  Copy the example and fill in your credentials:"
+    log_error "    cp $SCRIPT_DIR/llm.env.example $SCRIPT_DIR/llm.env"
+    log_error "  Then edit llm.env and set LLM_PROVIDER plus the required fields"
+    log_error "  for your provider (vertex-ai-anthropic, anthropic, or bob)."
+    exit 1
+fi
+
 log_validation_success "Validating Prerequisites"
 
 # Phase 1: validate LLM config and create K8s secrets BEFORE the installer
 # runs, so causa-backend has its credentials secret available on first startup.
-if [[ -f "$LLM_ENV_FILE" ]]; then
-    if ! validate_llm_config "$LLM_ENV_FILE"; then
-        exit 1
-    fi
-    log_validation_success "LLM Configuration"
+if ! validate_llm_config "$LLM_ENV_FILE"; then
+    exit 1
 fi
+log_validation_success "LLM Configuration"
 
 ensure_directory "$DEMO_DIR"
-cd "$DEMO_DIR"
-
-# Phase 1 (cont): create the GCP/LLM K8s secret now, before the installer.
-# On a fresh Kind cluster the namespace does not exist yet — the installer
-# creates it in Step 1. If the namespace is missing, kubectl will fail and
-# create_llm_secrets logs a non-fatal warning and continues. The installer
-# will then create the namespace and the secret can be re-created manually
-# or on the next run, but in practice the installer creates the namespace
-# before starting causa-backend so the missing secret is harmless for the
-# initial startup window.
-if [[ -f "$LLM_ENV_FILE" ]]; then
-    create_llm_secrets "$LLM_ENV_FILE" "$NAMESPACE"
-fi
+cd "$DEMO_DIR" || { log_error "Failed to change directory to $DEMO_DIR"; exit 1; }
 
 # ===========================================================================
 # Step 1: Run install.sh (Causa RCA stack on kind)
@@ -506,6 +511,12 @@ else
     INSTALLER_DIR="${INSTALLER_DIR:-}"
 fi
 
+# Phase 1 (cont): create the GCP/LLM K8s secret now that the cluster and
+# the Causa namespace exist. Moved here (after install.sh) so kubectl has a
+# live API server to talk to — running it before the Kind cluster is
+# provisioned caused connection-timeout errors.
+create_llm_secrets "$LLM_ENV_FILE" "$NAMESPACE"
+
 # ===========================================================================
 # Step 1.5: Clone chaos-lab and locate quarkus-perf manifests
 # ===========================================================================
@@ -551,7 +562,11 @@ if [[ -f "$LOAD_GEN_MANIFEST" ]]; then
 fi
 
 start_spinner "Creating namespace $NAMESPACE..."
-ensure_namespace "$NAMESPACE" 2>&1 | sed 's/\x1b\[[0-9;]*m//g' >>"$LOG_FILE"
+if ! ensure_namespace "$NAMESPACE"; then
+    stop_spinner
+    log_error "Failed to ensure namespace $NAMESPACE — cannot deploy workload"
+    exit 1
+fi
 stop_spinner
 
 # ── Deploy quarkus-perf ──────────────────────────────────────────────────

--- a/quarkus-rca/demo.sh
+++ b/quarkus-rca/demo.sh
@@ -265,7 +265,7 @@ fi
 if [[ "$TERMINATE" == "true" ]]; then
     terminate_demo "$NAMESPACE" "$DEMO_DIR" "$SKIP_INSTALLER"
 
-    # Remove causa-rca from project-level .mcp.json
+    # Remove causa-rca from project-level .mcp.json (cross-IDE root)
     _MCP_JSON_PATH="${SCRIPT_DIR}/../.mcp.json"
     if [[ -f "$_MCP_JSON_PATH" ]]; then
         start_spinner "Removing Causa MCP from project .mcp.json..."
@@ -291,6 +291,35 @@ PYEOF
         stop_spinner
         if [[ $_remove_mcp_json_rc -eq 0 ]]; then
             log_install_success "Causa MCP removed from project .mcp.json"
+        fi
+    fi
+
+    # Remove causa-rca from Bob project-level .bob/mcp.json (if it exists)
+    _BOB_MCP_JSON_PATH="${SCRIPT_DIR}/../.bob/mcp.json"
+    if [[ -f "$_BOB_MCP_JSON_PATH" ]]; then
+        start_spinner "Removing Causa MCP from .bob/mcp.json..."
+        _remove_bob_mcp_rc=1
+        if command_exists python3; then
+            python3 - "$_BOB_MCP_JSON_PATH" << 'PYEOF'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+    cfg.get("mcpServers", {}).pop("causa-rca", None)
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    print("removed")
+except Exception as e:
+    print(f"warn: {e}", file=sys.stderr)
+    sys.exit(1)
+PYEOF
+            _remove_bob_mcp_rc=$?
+        fi
+        stop_spinner
+        if [[ $_remove_bob_mcp_rc -eq 0 ]]; then
+            log_install_success "Causa MCP removed from .bob/mcp.json"
         fi
     fi
 
@@ -667,17 +696,31 @@ fi
 # Step 4: Register Causa MCP + install skill (optional)
 # ===========================================================================
 
-# ── 4a: Always write .mcp.json to the repo root ──────────────────────────
-# .mcp.json is the cross-IDE project-level MCP standard. Any IDE that
-# supports MCP (Claude shell, Cursor, Windsurf, VS Code Copilot, Gemini CLI)
-# auto-loads this file when the developer opens or cd's into the project —
-# no per-user setup required.
+# ── 4a: Write the correct MCP config file for the detected IDE ───────────
+# Bob IDE reads .bob/mcp.json; every other IDE (Claude Code CLI, Cursor,
+# Windsurf, VS Code Copilot, Gemini CLI) reads the cross-IDE .mcp.json at
+# the repo root. The two are mutually exclusive — we write exactly one.
 _MCP_JSON_PATH="${SCRIPT_DIR}/../.mcp.json"
-log_section "Step 4: Writing project-level .mcp.json"
-start_spinner "Writing .mcp.json to repo root..."
-_mcp_json_rc=1
-if command_exists python3; then
-    python3 - "$_MCP_JSON_PATH" "$CAUSA_MCP_URL" << 'PYEOF'
+_BOB_MCP_JSON_PATH="${SCRIPT_DIR}/../.bob/mcp.json"
+
+# Detect whether the user is configuring Bob
+_IS_BOB_SKILL_PATH=false
+if [[ -n "$SKILL_PATH" ]]; then
+    _expanded_skill_path="${SKILL_PATH/#\~/$HOME}"
+    if [[ "$_expanded_skill_path" == *"/.bob/"* || "$_expanded_skill_path" == *"/.bob" ]]; then
+        _IS_BOB_SKILL_PATH=true
+    fi
+fi
+
+log_section "Step 4: Writing project-level MCP config"
+
+# Helper: merge causa-rca entry into an existing or new JSON file
+_write_mcp_entry() {
+    local _target_path="$1"
+    local _target_dir
+    _target_dir="$(dirname "$_target_path")"
+    mkdir -p "$_target_dir"
+    python3 - "$_target_path" "$CAUSA_MCP_URL" << 'PYEOF'
 import json, sys, os
 path, url = sys.argv[1], sys.argv[2]
 cfg = {}
@@ -696,15 +739,65 @@ with open(path, "w") as f:
     f.write("\n")
 print("ok")
 PYEOF
-    _mcp_json_rc=$?
-fi
-stop_spinner
-if [[ $_mcp_json_rc -eq 0 ]]; then
-    log_install_success ".mcp.json written (${_MCP_JSON_PATH})"
-    write_to_log_file "INFO" ".mcp.json path: $_MCP_JSON_PATH"
+}
+
+if [[ "$_IS_BOB_SKILL_PATH" == "true" ]]; then
+    # Bob IDE: write .bob/mcp.json only
+    start_spinner "Writing .bob/mcp.json for Bob IDE..."
+    _bob_mcp_json_rc=1
+    if command_exists python3; then
+        _write_mcp_entry "$_BOB_MCP_JSON_PATH"
+        _bob_mcp_json_rc=$?
+    fi
+    stop_spinner
+    if [[ $_bob_mcp_json_rc -eq 0 ]]; then
+        log_install_success ".bob/mcp.json written (${_BOB_MCP_JSON_PATH})"
+        write_to_log_file "INFO" ".bob/mcp.json path: $_BOB_MCP_JSON_PATH"
+    else
+        log_file_only "Failed to write .bob/mcp.json — add manually via Bob Settings → MCP → Edit Project MCP"
+        log_validation_success ".bob/mcp.json (failed — add manually)"
+    fi
+elif [[ -n "$SKILL_PATH" ]]; then
+    # Explicit non-Bob skill path (e.g. Claude): write cross-IDE root .mcp.json only
+    start_spinner "Writing .mcp.json to repo root..."
+    _mcp_json_rc=1
+    if command_exists python3; then
+        _write_mcp_entry "$_MCP_JSON_PATH"
+        _mcp_json_rc=$?
+    fi
+    stop_spinner
+    if [[ $_mcp_json_rc -eq 0 ]]; then
+        log_install_success ".mcp.json written (${_MCP_JSON_PATH})"
+        write_to_log_file "INFO" ".mcp.json path: $_MCP_JSON_PATH"
+    else
+        log_file_only "Failed to write .mcp.json — add manually"
+        log_validation_success ".mcp.json (failed — add manually)"
+    fi
 else
-    log_file_only "Failed to write .mcp.json — add manually"
-    log_validation_success ".mcp.json (failed — add manually)"
+    # No --skill-path given: write both so any IDE works out of the box
+    start_spinner "Writing .mcp.json and .bob/mcp.json..."
+    _mcp_json_rc=1; _bob_mcp_json_rc=1
+    if command_exists python3; then
+        _write_mcp_entry "$_MCP_JSON_PATH"
+        _mcp_json_rc=$?
+        _write_mcp_entry "$_BOB_MCP_JSON_PATH"
+        _bob_mcp_json_rc=$?
+    fi
+    stop_spinner
+    if [[ $_mcp_json_rc -eq 0 ]]; then
+        log_install_success ".mcp.json written (${_MCP_JSON_PATH})"
+        write_to_log_file "INFO" ".mcp.json path: $_MCP_JSON_PATH"
+    else
+        log_file_only "Failed to write .mcp.json — add manually"
+        log_validation_success ".mcp.json (failed — add manually)"
+    fi
+    if [[ $_bob_mcp_json_rc -eq 0 ]]; then
+        log_install_success ".bob/mcp.json written (${_BOB_MCP_JSON_PATH})"
+        write_to_log_file "INFO" ".bob/mcp.json path: $_BOB_MCP_JSON_PATH"
+    else
+        log_file_only "Failed to write .bob/mcp.json — add manually via Bob Settings → MCP → Edit Project MCP"
+        log_validation_success ".bob/mcp.json (failed — add manually)"
+    fi
 fi
 
 # ── 4b: Install SKILL.md to user-supplied path (optional) ────────────────
@@ -875,7 +968,14 @@ _POD_DISPLAY="${_QP_POD:-quarkus-perf-<generated-suffix>}"
     echo ""
     echo -e "${COLOR_CYAN}Causa Backend:${COLOR_RESET} ${CAUSA_BACKEND_URL}/api/v1/diagnostics"
     echo -e "${COLOR_CYAN}Causa MCP:${COLOR_RESET}     ${CAUSA_MCP_URL}/mcp"
-    echo -e "${COLOR_CYAN}Project MCP config:${COLOR_RESET} ${SCRIPT_DIR}/../.mcp.json"
+    if [[ "$_IS_BOB_SKILL_PATH" == "true" ]]; then
+        echo -e "${COLOR_CYAN}Bob MCP config:${COLOR_RESET}     ${SCRIPT_DIR}/../.bob/mcp.json"
+    elif [[ -n "$SKILL_PATH" ]]; then
+        echo -e "${COLOR_CYAN}Project MCP config:${COLOR_RESET} ${SCRIPT_DIR}/../.mcp.json"
+    else
+        echo -e "${COLOR_CYAN}Project MCP config:${COLOR_RESET} ${SCRIPT_DIR}/../.mcp.json"
+        echo -e "${COLOR_CYAN}Bob MCP config:${COLOR_RESET}     ${SCRIPT_DIR}/../.bob/mcp.json"
+    fi
     echo ""
 
     # ── Skill setup summary ─────────────────────────────────────────────────

--- a/quarkus-rca/images.env
+++ b/quarkus-rca/images.env
@@ -17,7 +17,7 @@
 K8S_MCP_SERVER_IMAGE=quay.io/containers/kubernetes_mcp_server:v0.0.62
 
 # Causa backend
-CAUSA_BACKEND_IMAGE=${CAUSA_BACKEND_IMAGE:-quay.io/rh-ee-shesaxen/causa-backend:mvp_demo_250826}
+CAUSA_BACKEND_IMAGE=${CAUSA_BACKEND_IMAGE:-quay.io/causa-ai-hub/causa-backend:0.0.2}
 
 # Causa MCP server 
 CAUSA_MCP_IMAGE=${CAUSA_MCP_IMAGE:-quay.io/causa-ai-hub/causa-mcp-server:0.0.1}

--- a/quarkus-rca/lib/llm.sh
+++ b/quarkus-rca/lib/llm.sh
@@ -170,6 +170,7 @@ create_llm_secrets() {
                 return 0
             fi
 
+            # Create GCP secret once kind cluster is up or causa is deployed
             start_spinner "Creating causa-gcp-credentials secret..."
             if kubectl create secret generic causa-gcp-credentials \
                     --from-file="key.json=$creds_file" \

--- a/quarkus-rca/lib/llm.sh
+++ b/quarkus-rca/lib/llm.sh
@@ -229,12 +229,13 @@ create_llm_secrets() {
 #
 # Most keys posted here are non-sensitive (LLM_PROVIDER, LLM_MODEL_NAME,
 # VERTEX_PROJECT_ID, VERTEX_LOCATION).  Exceptions:
+#   vertex-ai-anthropic — GOOGLE_APPLICATION_CREDENTIALS is included as the
+#               base64-encoded contents of the credentials file.  The backend
+#               deployment has no volume mount for the GCP secret, so the
+#               credential must reach it via this config endpoint.
 #   anthropic — LLM_API_KEY is included (no volume-mount path available).
 #   bob       — LLM_API_KEY (when set) and BOB_SHELL_PATH (when set) are
 #               included so the backend knows how to invoke Bob.
-#
-# The GCP credential is NOT POSTed — it is already available to the backend
-# via the K8s Secret volume mount created in Phase 1.
 #
 # NOTE: both create_llm_secrets and configure_llm_runtime source llm.env
 # directly into the current shell with `set -a` (required so kubectl/curl
@@ -260,10 +261,10 @@ configure_llm_runtime() {
     source "$llm_env_file"
     set +a
 
-    # Build the payload — only non-sensitive keys.
+    # Build the payload.
     local payload
     payload=$(python3 - << 'PYEOF'
-import os, json
+import os, json, base64
 
 configs = {}
 
@@ -283,8 +284,15 @@ vertex_loc  = os.getenv("VERTEX_LOCATION",   "").strip()
 if vertex_proj: configs["VERTEX_PROJECT_ID"] = vertex_proj
 if vertex_loc:  configs["VERTEX_LOCATION"]   = vertex_loc
 
+# Vertex AI — base64-encode the service account key file and POST it as
+# GOOGLE_APPLICATION_CREDENTIALS (the backend deployment has no volume mount).
+if provider == "vertex-ai-anthropic":
+    creds_path = os.path.expandvars(os.path.expanduser(os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "").strip()))
+    if creds_path and os.path.isfile(creds_path):
+        with open(creds_path, "rb") as f:
+            configs["GOOGLE_APPLICATION_CREDENTIALS"] = base64.b64encode(f.read()).decode("utf-8")
+
 # Anthropic / Bob — API key must go via the API (no volume mount for these providers)
-provider = configs.get("LLM_PROVIDER", "")
 if provider in ("anthropic", "bob"):
     api_key = os.getenv("LLM_API_KEY", "").strip()
     if api_key:
@@ -356,6 +364,130 @@ print(', '.join(keys))
     else
         log_file_only "Config push failed after 5 attempts (non-fatal — RCA will run without LLM)"
         log_validation_success "Causa config push (failed — check ${LOG_FILE})"
+    fi
+
+    # For vertex-ai-anthropic the Google ADC library resolves credentials via
+    # the GOOGLE_APPLICATION_CREDENTIALS *environment variable* at runtime —
+    # it does not read the value from the /api/v1/configs store.  The secret
+    # was already created by create_llm_secrets, so we just need to:
+    #   1. Mount it into the causa-backend pod at /var/secrets/google/key.json
+    #   2. Set GOOGLE_APPLICATION_CREDENTIALS to that path in the container env
+    # We patch the live Deployment here so this is always applied, even on
+    # --skip-installer runs or when the installer did not include the mount.
+    if [[ "${LLM_PROVIDER:-}" == "vertex-ai-anthropic" ]]; then
+        _patch_vertex_ai_credential_mount "$namespace"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# _patch_vertex_ai_credential_mount  NAMESPACE
+#
+# Patches the causa-backend Deployment to:
+#   • Mount the causa-gcp-credentials secret at /var/secrets/google
+#   • Set GOOGLE_APPLICATION_CREDENTIALS=/var/secrets/google/key.json
+#
+# Idempotent — checks whether the mount already exists before patching.
+# Rolls out the new pod and waits up to 120s for it to become ready.
+# Non-fatal: logs a warning and returns 0 on any failure so the rest of
+# the demo continues (RCA may fail at runtime, but setup does not abort).
+# ---------------------------------------------------------------------------
+_patch_vertex_ai_credential_mount() {
+    local namespace="$1"
+
+    # Check whether the volume mount is already present — if so, skip.
+    local existing_mount
+    existing_mount=$(kubectl get deployment causa-backend \
+        -n "$namespace" \
+        -o jsonpath='{.spec.template.spec.volumes[?(@.name=="gcp-credentials")].name}' \
+        2>>"${LOG_FILE}" || true)
+
+    if [[ "$existing_mount" == "gcp-credentials" ]]; then
+        write_to_log_file "INFO" "_patch_vertex_ai_credential_mount: volume already present — skipping patch"
+        return 0
+    fi
+
+    # Verify the secret exists before patching.
+    if ! kubectl get secret causa-gcp-credentials \
+            -n "$namespace" >>"${LOG_FILE}" 2>&1; then
+        write_to_log_file "WARN" "_patch_vertex_ai_credential_mount: causa-gcp-credentials secret not found in $namespace — skipping mount patch"
+        return 0
+    fi
+
+    start_spinner "Patching causa-backend with GCP credential mount..."
+
+    local patch_rc=0
+    kubectl patch deployment causa-backend \
+        -n "$namespace" \
+        --type=json \
+        -p '[
+          {
+            "op": "add",
+            "path": "/spec/template/spec/volumes/-",
+            "value": {
+              "name": "gcp-credentials",
+              "secret": { "secretName": "causa-gcp-credentials" }
+            }
+          },
+          {
+            "op": "add",
+            "path": "/spec/template/spec/containers/0/volumeMounts/-",
+            "value": {
+              "name": "gcp-credentials",
+              "mountPath": "/var/secrets/google",
+              "readOnly": true
+            }
+          },
+          {
+            "op": "add",
+            "path": "/spec/template/spec/containers/0/env/-",
+            "value": {
+              "name": "GOOGLE_APPLICATION_CREDENTIALS",
+              "value": "/var/secrets/google/key.json"
+            }
+          }
+        ]' >>"${LOG_FILE}" 2>&1 || patch_rc=$?
+
+    stop_spinner
+
+    if [[ $patch_rc -ne 0 ]]; then
+        write_to_log_file "WARN" "_patch_vertex_ai_credential_mount: kubectl patch failed (rc=$patch_rc) — Vertex AI ADC will not find credentials at runtime"
+        log_validation_success "GCP credential mount patch (failed — check ${LOG_FILE})"
+        return 0
+    fi
+
+    log_install_success "causa-backend patched with GCP credential volume mount"
+
+    # Delete the old pod so the new ReplicaSet pod (with the mount) starts
+    # immediately instead of waiting for the rolling-update deadlock on a
+    # single-node cluster where memory is tight.
+    local old_pod
+    old_pod=$(kubectl get pods \
+        -l "app=causa-backend" \
+        -n "$namespace" \
+        --field-selector="status.phase=Running" \
+        -o "jsonpath={.items[0].metadata.name}" \
+        2>>"${LOG_FILE}" || true)
+
+    if [[ -n "$old_pod" ]]; then
+        start_spinner "Restarting causa-backend pod ($old_pod)..."
+        kubectl delete pod "$old_pod" -n "$namespace" >>"${LOG_FILE}" 2>&1 || true
+        stop_spinner
+        write_to_log_file "INFO" "Deleted old causa-backend pod $old_pod to free memory for rolling update"
+    fi
+
+    # Wait for the new pod to be ready (up to 120s).
+    start_spinner "Waiting for causa-backend to be ready after credential patch (up to 120s)..."
+    local wait_rc=0
+    kubectl rollout status deployment/causa-backend \
+        -n "$namespace" \
+        --timeout=120s >>"${LOG_FILE}" 2>&1 || wait_rc=$?
+    stop_spinner
+
+    if [[ $wait_rc -eq 0 ]]; then
+        log_install_success "causa-backend restarted and ready with GCP credentials"
+    else
+        write_to_log_file "WARN" "_patch_vertex_ai_credential_mount: rollout did not complete within 120s (rc=$wait_rc) — pod may still be starting"
+        log_validation_success "causa-backend rollout (timed out — check: kubectl get pods -n $namespace)"
     fi
 }
 

--- a/quarkus-rca/lib/llm.sh
+++ b/quarkus-rca/lib/llm.sh
@@ -15,11 +15,7 @@
 #
 #   configure_llm_runtime  LLM_ENV_FILE  NAMESPACE
 #     Phase 2 — called AFTER the installer.
-#     POSTs only the non-sensitive config keys (LLM_PROVIDER, LLM_MODEL_NAME,
-#     VERTEX_PROJECT_ID, VERTEX_LOCATION) to POST /api/v1/configs.
-#     The GCP credential reaches the backend via the K8s Secret created in
-#     Phase 1 and the GOOGLE_APPLICATION_CREDENTIALS env var set in the
-#     causa-backend deployment — it is never POSTed through the API.
+#     POSTs config keys to /api/v1/configs. GCP credentials are never POSTed.
 ################################################################################
 
 # Source guard
@@ -58,6 +54,9 @@ validate_llm_config() {
     location=$(       bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_LOCATION:-}\"")
     project_id=$(     bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_PROJECT_ID:-}\"")
     creds_file=$(     bash -c "set -a; source \"$llm_env_file\"; eval echo \"\${GOOGLE_APPLICATION_CREDENTIALS:-}\"")
+    if [[ -n "$creds_file" && "$creds_file" != /* ]]; then
+        creds_file="$(dirname "$llm_env_file")/$creds_file"
+    fi
     api_key=$(        bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_API_KEY:-}\"")
     bob_shell_path=$( bash -c "set -a; source \"$llm_env_file\"; echo \"\${BOB_SHELL_PATH:-\${BOB_PATH:-}}\"")
 
@@ -165,9 +164,9 @@ create_llm_secrets() {
             fi
 
             if [[ ! -f "$creds_file" ]]; then
-                write_to_log_file "WARN" "GCP credentials file not found at $creds_file"
-                write_to_log_file "WARN" "Set GOOGLE_APPLICATION_CREDENTIALS in llm.env or place causa-gcp-key.json next to demo.sh"
-                return 0
+                write_to_log_file "ERROR" "GCP credentials file not found at $creds_file"
+                write_to_log_file "ERROR" "Set GOOGLE_APPLICATION_CREDENTIALS in llm.env or place causa-gcp-key.json next to demo.sh"
+                return 1
             fi
 
             # Create GCP secret once kind cluster is up or causa is deployed
@@ -180,6 +179,7 @@ create_llm_secrets() {
             else
                 stop_spinner
                 log_file_only "Failed to create causa-gcp-credentials — check ${LOG_FILE}"
+                return 1
             fi
             ;;
 
@@ -213,6 +213,7 @@ create_llm_secrets() {
             else
                 stop_spinner
                 log_file_only "Failed to create causa-llm-secrets — check ${LOG_FILE}"
+                return 1
             fi
             ;;
 
@@ -228,15 +229,16 @@ create_llm_secrets() {
 # Phase 2 — POST config keys to the running causa-backend after the
 # installer has deployed it.
 #
-# Most keys posted here are non-sensitive (LLM_PROVIDER, LLM_MODEL_NAME,
+# Keys posted here are non-sensitive (LLM_PROVIDER, LLM_MODEL_NAME,
 # VERTEX_PROJECT_ID, VERTEX_LOCATION).  Exceptions:
-#   vertex-ai-anthropic — GOOGLE_APPLICATION_CREDENTIALS is included as the
-#               base64-encoded contents of the credentials file.  The backend
-#               deployment has no volume mount for the GCP secret, so the
-#               credential must reach it via this config endpoint.
 #   anthropic — LLM_API_KEY is included (no volume-mount path available).
 #   bob       — LLM_API_KEY (when set) and BOB_SHELL_PATH (when set) are
 #               included so the backend knows how to invoke Bob.
+#
+# vertex-ai-anthropic — GOOGLE_APPLICATION_CREDENTIALS is NOT posted here.
+#   The credential reaches the backend exclusively via the K8s Secret
+#   (created by create_llm_secrets) and the volume mount applied by
+#   _patch_vertex_ai_credential_mount.
 #
 # NOTE: both create_llm_secrets and configure_llm_runtime source llm.env
 # directly into the current shell with `set -a` (required so kubectl/curl
@@ -284,14 +286,6 @@ vertex_proj = os.getenv("VERTEX_PROJECT_ID", "").strip()
 vertex_loc  = os.getenv("VERTEX_LOCATION",   "").strip()
 if vertex_proj: configs["VERTEX_PROJECT_ID"] = vertex_proj
 if vertex_loc:  configs["VERTEX_LOCATION"]   = vertex_loc
-
-# Vertex AI — base64-encode the service account key file and POST it as
-# GOOGLE_APPLICATION_CREDENTIALS (the backend deployment has no volume mount).
-if provider == "vertex-ai-anthropic":
-    creds_path = os.path.expandvars(os.path.expanduser(os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "").strip()))
-    if creds_path and os.path.isfile(creds_path):
-        with open(creds_path, "rb") as f:
-            configs["GOOGLE_APPLICATION_CREDENTIALS"] = base64.b64encode(f.read()).decode("utf-8")
 
 # Anthropic / Bob — API key must go via the API (no volume mount for these providers)
 if provider in ("anthropic", "bob"):

--- a/quarkus-rca/lib/llm.sh
+++ b/quarkus-rca/lib/llm.sh
@@ -33,7 +33,7 @@ readonly LLM_LIB_LOADED=1
 # credentials file exists. Sources LLM_ENV_FILE in a subshell so the parent
 # environment is not polluted. Exits with clear error messages on failure.
 #
-# Supported providers:  vertex-ai-anthropic  |  anthropic
+# Supported providers:  vertex-ai-anthropic  |  anthropic  |  bob
 # ---------------------------------------------------------------------------
 validate_llm_config() {
     local llm_env_file="$1"
@@ -52,13 +52,14 @@ validate_llm_config() {
     fi
 
     # Read values in subshells — never pollute the parent environment here.
-    local provider model_name location project_id creds_file api_key
-    provider=$(    bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_PROVIDER:-}\"")
-    model_name=$(  bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_MODEL_NAME:-}\"")
-    location=$(    bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_LOCATION:-}\"")
-    project_id=$(  bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_PROJECT_ID:-}\"")
-    creds_file=$(  bash -c "set -a; source \"$llm_env_file\"; eval echo \"\${GOOGLE_APPLICATION_CREDENTIALS:-}\"")
-    api_key=$(     bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_API_KEY:-}\"")
+    local provider model_name location project_id creds_file api_key bob_shell_path
+    provider=$(       bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_PROVIDER:-}\"")
+    model_name=$(     bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_MODEL_NAME:-}\"")
+    location=$(       bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_LOCATION:-}\"")
+    project_id=$(     bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_PROJECT_ID:-}\"")
+    creds_file=$(     bash -c "set -a; source \"$llm_env_file\"; eval echo \"\${GOOGLE_APPLICATION_CREDENTIALS:-}\"")
+    api_key=$(        bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_API_KEY:-}\"")
+    bob_shell_path=$( bash -c "set -a; source \"$llm_env_file\"; echo \"\${BOB_SHELL_PATH:-\${BOB_PATH:-}}\"")
 
     log_file_only "LLM validation: reading from $llm_env_file"
 
@@ -85,11 +86,18 @@ validate_llm_config() {
             [[ -z "$model_name" ]] && errors+=("LLM_MODEL_NAME is not set")
             [[ -z "$api_key"    ]] && errors+=("LLM_API_KEY is not set")
             ;;
+        bob)
+            # BOB_SHELL_PATH is optional — the backend defaults to 'bob' on PATH.
+            # LLM_API_KEY is required when Bob uses API-key authentication.
+            if [[ -n "$bob_shell_path" && ! -x "$bob_shell_path" ]]; then
+                errors+=("BOB_SHELL_PATH='$bob_shell_path' is not executable")
+            fi
+            ;;
         "")
             : # already captured above
             ;;
         *)
-            errors+=("LLM_PROVIDER='$provider' is not supported (supported: vertex-ai-anthropic, anthropic)")
+            errors+=("LLM_PROVIDER='$provider' is not supported (supported: vertex-ai-anthropic, anthropic, bob)")
             ;;
     esac
 
@@ -118,8 +126,9 @@ validate_llm_config() {
 #     /var/secrets/google/key.json via the GOOGLE_APPLICATION_CREDENTIALS
 #     env var (set in the deployment manifest).
 #
-#   anthropic:
+#   anthropic | bob:
 #     causa-llm-secrets — LLM_API_KEY stored as a K8s secret.
+#     (bob only creates this secret when LLM_API_KEY is set in llm.env)
 #
 # No-op (with a warning) if the credentials file is missing.
 # ---------------------------------------------------------------------------
@@ -173,7 +182,13 @@ create_llm_secrets() {
             fi
             ;;
 
-        anthropic)
+        anthropic|bob)
+            # bob only needs a secret when LLM_API_KEY is set (API-key auth).
+            if [[ "${LLM_PROVIDER:-}" == "bob" && -z "${LLM_API_KEY:-}" ]]; then
+                write_to_log_file "INFO" "create_llm_secrets: provider=bob with no LLM_API_KEY — no secret needed"
+                return 0
+            fi
+
             if kubectl get secret causa-llm-secrets \
                     -n "$namespace" >>"${LOG_FILE}" 2>&1; then
                 write_to_log_file "INFO" "causa-llm-secrets already exists in $namespace — skipping creation"
@@ -213,9 +228,10 @@ create_llm_secrets() {
 # installer has deployed it.
 #
 # Most keys posted here are non-sensitive (LLM_PROVIDER, LLM_MODEL_NAME,
-# VERTEX_PROJECT_ID, VERTEX_LOCATION).  Exception: when LLM_PROVIDER=anthropic
-# the API key (LLM_API_KEY) is also included in the payload because there is
-# no volume-mount path for it — the backend has no other way to receive it.
+# VERTEX_PROJECT_ID, VERTEX_LOCATION).  Exceptions:
+#   anthropic — LLM_API_KEY is included (no volume-mount path available).
+#   bob       — LLM_API_KEY (when set) and BOB_SHELL_PATH (when set) are
+#               included so the backend knows how to invoke Bob.
 #
 # The GCP credential is NOT POSTed — it is already available to the backend
 # via the K8s Secret volume mount created in Phase 1.
@@ -267,13 +283,18 @@ vertex_loc  = os.getenv("VERTEX_LOCATION",   "").strip()
 if vertex_proj: configs["VERTEX_PROJECT_ID"] = vertex_proj
 if vertex_loc:  configs["VERTEX_LOCATION"]   = vertex_loc
 
-# Anthropic direct — API key is sensitive but must go via the API (no volume mount)
-api_key = os.getenv("LLM_API_KEY", "").strip()
-if api_key: configs["LLM_API_KEY"] = api_key
+# Anthropic / Bob — API key must go via the API (no volume mount for these providers)
+provider = configs.get("LLM_PROVIDER", "")
+if provider in ("anthropic", "bob"):
+    api_key = os.getenv("LLM_API_KEY", "").strip()
+    if api_key:
+        configs["LLM_API_KEY"] = api_key
 
-# Bob provider
-bob_path = os.getenv("BOB_SHELL_PATH", os.getenv("BOB_PATH", "")).strip()
-if bob_path: configs["BOB_SHELL_PATH"] = bob_path
+# Bob provider — optional path to the bob binary
+if provider == "bob":
+    bob_path = os.getenv("BOB_SHELL_PATH", os.getenv("BOB_PATH", "")).strip()
+    if bob_path:
+        configs["BOB_SHELL_PATH"] = bob_path
 
 print(json.dumps({"configs": configs}))
 PYEOF
@@ -292,7 +313,14 @@ print('true' if json.loads(sys.argv[1]).get('configs') else 'false')
         return 0
     fi
 
-    write_to_log_file "INFO" "Pushing LLM config (provider: ${LLM_PROVIDER:-}, model: ${LLM_MODEL_NAME:-})"
+    # Log what is being pushed (keys only — values are redacted from the log).
+    local _payload_keys
+    _payload_keys=$(python3 -c "
+import json, sys
+keys = list(json.loads(sys.argv[1]).get('configs', {}).keys())
+print(', '.join(keys))
+" "$payload" 2>/dev/null || echo "unknown")
+    write_to_log_file "INFO" "Pushing LLM config (provider: ${LLM_PROVIDER:-}, keys: $_payload_keys)"
 
     local causa_pod
     causa_pod=$(kubectl get pods \

--- a/quarkus-rca/lib/llm.sh
+++ b/quarkus-rca/lib/llm.sh
@@ -128,7 +128,11 @@ create_llm_secrets() {
     local namespace="$2"
 
     # Source so variables are available to the rest of this function.
-    # set -a ensures they're exported for any child processes too.
+    # set -a ensures they're exported for any child processes (kubectl) too.
+    # Side-effect: LLM_API_KEY, GOOGLE_APPLICATION_CREDENTIALS, etc. are
+    # exported into the parent shell for the rest of the run.  This is
+    # intentional — kubectl needs them — but differs from validate_llm_config
+    # which uses subshells.  See the configure_llm_runtime docstring for details.
     set -a
     # shellcheck disable=SC1090
     source "$llm_env_file"
@@ -205,14 +209,25 @@ create_llm_secrets() {
 # ---------------------------------------------------------------------------
 # configure_llm_runtime  LLM_ENV_FILE  NAMESPACE
 #
-# Phase 2 — POST non-sensitive config to the running causa-backend after the
+# Phase 2 — POST config keys to the running causa-backend after the
 # installer has deployed it.
 #
-# Only non-sensitive keys are sent here:
-#   LLM_PROVIDER, LLM_MODEL_NAME, VERTEX_PROJECT_ID, VERTEX_LOCATION
+# Most keys posted here are non-sensitive (LLM_PROVIDER, LLM_MODEL_NAME,
+# VERTEX_PROJECT_ID, VERTEX_LOCATION).  Exception: when LLM_PROVIDER=anthropic
+# the API key (LLM_API_KEY) is also included in the payload because there is
+# no volume-mount path for it — the backend has no other way to receive it.
 #
 # The GCP credential is NOT POSTed — it is already available to the backend
 # via the K8s Secret volume mount created in Phase 1.
+#
+# NOTE: both create_llm_secrets and configure_llm_runtime source llm.env
+# directly into the current shell with `set -a` (required so kubectl/curl
+# child processes can read the exported variables).  This means LLM_API_KEY,
+# GOOGLE_APPLICATION_CREDENTIALS, etc. remain exported for the rest of the
+# demo.sh process.  validate_llm_config uses subshells to avoid this, but
+# the secret-creation and config-push phases cannot — they need the vars
+# live in the environment.  Be aware of this if you add callers that do not
+# expect those variables to be set.
 #
 # Uses kubectl exec + curl (same as the installer pattern) so no external
 # route is needed — works identically on Kind and OpenShift.
@@ -222,6 +237,8 @@ configure_llm_runtime() {
     local namespace="$2"
 
     # Source with set -a so all vars are exported for child processes.
+    # Side-effect: LLM_API_KEY, GOOGLE_APPLICATION_CREDENTIALS, etc. are
+    # exported into the parent shell for the rest of the run (see docstring).
     set -a
     # shellcheck disable=SC1090
     source "$llm_env_file"
@@ -314,6 +331,3 @@ print('true' if json.loads(sys.argv[1]).get('configs') else 'false')
     fi
 }
 
-export -f validate_llm_config
-export -f create_llm_secrets
-export -f configure_llm_runtime

--- a/quarkus-rca/lib/llm.sh
+++ b/quarkus-rca/lib/llm.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+################################################################################
+# LLM configuration helpers for the Quarkus RCA demo.
+#
+# Mirrors the two-phase pattern from runtimes-intelligence-demo/lib/llm.sh:
+#
+#   validate_llm_config  LLM_ENV_FILE
+#     Validates required fields before any deployment starts.
+#     Exits early with clear errors on misconfiguration.
+#
+#   create_llm_secrets  LLM_ENV_FILE  NAMESPACE
+#     Phase 1 — called BEFORE the installer.
+#     Creates the causa-gcp-credentials K8s Secret from the credentials file
+#     so the secret exists when the installer deploys causa-backend.
+#
+#   configure_llm_runtime  LLM_ENV_FILE  NAMESPACE
+#     Phase 2 — called AFTER the installer.
+#     POSTs only the non-sensitive config keys (LLM_PROVIDER, LLM_MODEL_NAME,
+#     VERTEX_PROJECT_ID, VERTEX_LOCATION) to POST /api/v1/configs.
+#     The GCP credential reaches the backend via the K8s Secret created in
+#     Phase 1 and the GOOGLE_APPLICATION_CREDENTIALS env var set in the
+#     causa-backend deployment — it is never POSTed through the API.
+################################################################################
+
+# Source guard
+if [[ -n "${LLM_LIB_LOADED:-}" ]]; then return 0; fi
+readonly LLM_LIB_LOADED=1
+
+# ---------------------------------------------------------------------------
+# validate_llm_config  LLM_ENV_FILE
+#
+# Checks that all required fields for the chosen provider are present and the
+# credentials file exists. Sources LLM_ENV_FILE in a subshell so the parent
+# environment is not polluted. Exits with clear error messages on failure.
+#
+# Supported providers:  vertex-ai-anthropic  |  anthropic
+# ---------------------------------------------------------------------------
+validate_llm_config() {
+    local llm_env_file="$1"
+    local errors=()
+
+    if [[ -z "$llm_env_file" ]]; then
+        log_error "validate_llm_config: llm.env path not provided"
+        log_error "  Copy llm.env.example to llm.env and fill in your values"
+        return 1
+    fi
+
+    if [[ ! -f "$llm_env_file" ]]; then
+        log_error "LLM configuration file not found: $llm_env_file"
+        log_error "  cp $(dirname "$llm_env_file")/llm.env.example $llm_env_file"
+        return 1
+    fi
+
+    # Read values in subshells — never pollute the parent environment here.
+    local provider model_name location project_id creds_file api_key
+    provider=$(    bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_PROVIDER:-}\"")
+    model_name=$(  bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_MODEL_NAME:-}\"")
+    location=$(    bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_LOCATION:-}\"")
+    project_id=$(  bash -c "set -a; source \"$llm_env_file\"; echo \"\${VERTEX_PROJECT_ID:-}\"")
+    creds_file=$(  bash -c "set -a; source \"$llm_env_file\"; eval echo \"\${GOOGLE_APPLICATION_CREDENTIALS:-}\"")
+    api_key=$(     bash -c "set -a; source \"$llm_env_file\"; echo \"\${LLM_API_KEY:-}\"")
+
+    log_file_only "LLM validation: reading from $llm_env_file"
+
+    if [[ -z "$provider" ]]; then
+        errors+=("LLM_PROVIDER is not set in $llm_env_file")
+    fi
+
+    case "$provider" in
+        vertex-ai-anthropic)
+            [[ -z "$model_name"  ]] && errors+=("LLM_MODEL_NAME is not set")
+            [[ -z "$project_id"  ]] && errors+=("VERTEX_PROJECT_ID is not set")
+            if [[ -z "$location" ]]; then
+                errors+=("VERTEX_LOCATION is not set (valid: us-east5, us-central1, europe-west1, asia-southeast1)")
+            elif [[ "$location" == "global" ]]; then
+                errors+=("VERTEX_LOCATION='global' is not valid for Claude on Vertex AI — use us-east5, us-central1, europe-west1, or asia-southeast1")
+            fi
+            if [[ -z "$creds_file" ]]; then
+                errors+=("GOOGLE_APPLICATION_CREDENTIALS is not set in $llm_env_file")
+            elif [[ ! -f "$creds_file" ]]; then
+                errors+=("GOOGLE_APPLICATION_CREDENTIALS='$creds_file' does not exist")
+            fi
+            ;;
+        anthropic)
+            [[ -z "$model_name" ]] && errors+=("LLM_MODEL_NAME is not set")
+            [[ -z "$api_key"    ]] && errors+=("LLM_API_KEY is not set")
+            ;;
+        "")
+            : # already captured above
+            ;;
+        *)
+            errors+=("LLM_PROVIDER='$provider' is not supported (supported: vertex-ai-anthropic, anthropic)")
+            ;;
+    esac
+
+    if [[ ${#errors[@]} -gt 0 ]]; then
+        log_error "LLM configuration validation failed ($llm_env_file):"
+        for err in "${errors[@]}"; do
+            log_error "  • $err"
+            log_file_only "LLM validation error: $err"
+        done
+        log_error "Edit $llm_env_file and fix the above before re-running."
+        return 1
+    fi
+
+    log_file_only "LLM validation passed: provider=$provider"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# create_llm_secrets  LLM_ENV_FILE  NAMESPACE
+#
+# Phase 1 — create K8s secrets BEFORE the installer runs.
+#
+#   vertex-ai-anthropic:
+#     causa-gcp-credentials — the raw credentials file stored as key.json,
+#     mounted by the causa-backend deployment at
+#     /var/secrets/google/key.json via the GOOGLE_APPLICATION_CREDENTIALS
+#     env var (set in the deployment manifest).
+#
+#   anthropic:
+#     causa-llm-secrets — LLM_API_KEY stored as a K8s secret.
+#
+# No-op (with a warning) if the credentials file is missing.
+# ---------------------------------------------------------------------------
+create_llm_secrets() {
+    local llm_env_file="$1"
+    local namespace="$2"
+
+    # Source so variables are available to the rest of this function.
+    # set -a ensures they're exported for any child processes too.
+    set -a
+    # shellcheck disable=SC1090
+    source "$llm_env_file"
+    set +a
+
+    local creds_file
+    creds_file=$(eval echo "${GOOGLE_APPLICATION_CREDENTIALS:-}")
+    # Also accept a local causa-gcp-key.json next to the script as a fallback
+    if [[ -z "$creds_file" || ! -f "$creds_file" ]]; then
+        if [[ -f "$SCRIPT_DIR/causa-gcp-key.json" ]]; then
+            creds_file="$SCRIPT_DIR/causa-gcp-key.json"
+        fi
+    fi
+
+    case "${LLM_PROVIDER:-}" in
+        vertex-ai-anthropic)
+            if kubectl get secret causa-gcp-credentials \
+                    -n "$namespace" >>"${LOG_FILE}" 2>&1; then
+                write_to_log_file "INFO" "causa-gcp-credentials already exists in $namespace — skipping creation"
+                return 0
+            fi
+
+            if [[ ! -f "$creds_file" ]]; then
+                write_to_log_file "WARN" "GCP credentials file not found at $creds_file"
+                write_to_log_file "WARN" "Set GOOGLE_APPLICATION_CREDENTIALS in llm.env or place causa-gcp-key.json next to demo.sh"
+                return 0
+            fi
+
+            start_spinner "Creating causa-gcp-credentials secret..."
+            if kubectl create secret generic causa-gcp-credentials \
+                    --from-file="key.json=$creds_file" \
+                    -n "$namespace" >>"${LOG_FILE}" 2>&1; then
+                stop_spinner
+                log_install_success "causa-gcp-credentials secret created"
+            else
+                stop_spinner
+                log_file_only "Failed to create causa-gcp-credentials — check ${LOG_FILE}"
+            fi
+            ;;
+
+        anthropic)
+            if kubectl get secret causa-llm-secrets \
+                    -n "$namespace" >>"${LOG_FILE}" 2>&1; then
+                write_to_log_file "INFO" "causa-llm-secrets already exists in $namespace — skipping creation"
+                return 0
+            fi
+
+            # Write key to a temp file so it never appears in ps output.
+            local api_key_tmp
+            api_key_tmp=$(mktemp /tmp/.llm_secret.XXXXXX)
+            chmod 600 "$api_key_tmp"
+            printf '%s' "${LLM_API_KEY:-}" > "$api_key_tmp"
+            local secret_rc=0
+            start_spinner "Creating causa-llm-secrets..."
+            kubectl create secret generic causa-llm-secrets \
+                    --from-file=LLM_API_KEY="$api_key_tmp" \
+                    -n "$namespace" >>"${LOG_FILE}" 2>&1 || secret_rc=$?
+            shred -u "$api_key_tmp" 2>/dev/null || rm -f "$api_key_tmp"
+            if [[ $secret_rc -eq 0 ]]; then
+                stop_spinner
+                log_install_success "causa-llm-secrets created"
+            else
+                stop_spinner
+                log_file_only "Failed to create causa-llm-secrets — check ${LOG_FILE}"
+            fi
+            ;;
+
+        *)
+            write_to_log_file "INFO" "create_llm_secrets: provider '${LLM_PROVIDER:-}' needs no K8s secret — skipping"
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# configure_llm_runtime  LLM_ENV_FILE  NAMESPACE
+#
+# Phase 2 — POST non-sensitive config to the running causa-backend after the
+# installer has deployed it.
+#
+# Only non-sensitive keys are sent here:
+#   LLM_PROVIDER, LLM_MODEL_NAME, VERTEX_PROJECT_ID, VERTEX_LOCATION
+#
+# The GCP credential is NOT POSTed — it is already available to the backend
+# via the K8s Secret volume mount created in Phase 1.
+#
+# Uses kubectl exec + curl (same as the installer pattern) so no external
+# route is needed — works identically on Kind and OpenShift.
+# ---------------------------------------------------------------------------
+configure_llm_runtime() {
+    local llm_env_file="$1"
+    local namespace="$2"
+
+    # Source with set -a so all vars are exported for child processes.
+    set -a
+    # shellcheck disable=SC1090
+    source "$llm_env_file"
+    set +a
+
+    # Build the payload — only non-sensitive keys.
+    local payload
+    payload=$(python3 - << 'PYEOF'
+import os, json
+
+configs = {}
+
+provider    = os.getenv("LLM_PROVIDER",    "").strip()
+model       = os.getenv("LLM_MODEL_NAME",  "").strip()
+temperature = os.getenv("LLM_TEMPERATURE", "").strip()
+endpoint    = os.getenv("LLM_ENDPOINT",    "").strip()
+
+if provider:    configs["LLM_PROVIDER"]    = provider
+if model:       configs["LLM_MODEL_NAME"]  = model
+if temperature: configs["LLM_TEMPERATURE"] = temperature
+if endpoint:    configs["LLM_ENDPOINT"]    = endpoint
+
+# Vertex AI — project and location are non-sensitive
+vertex_proj = os.getenv("VERTEX_PROJECT_ID", "").strip()
+vertex_loc  = os.getenv("VERTEX_LOCATION",   "").strip()
+if vertex_proj: configs["VERTEX_PROJECT_ID"] = vertex_proj
+if vertex_loc:  configs["VERTEX_LOCATION"]   = vertex_loc
+
+# Anthropic direct — API key is sensitive but must go via the API (no volume mount)
+api_key = os.getenv("LLM_API_KEY", "").strip()
+if api_key: configs["LLM_API_KEY"] = api_key
+
+# Bob provider
+bob_path = os.getenv("BOB_SHELL_PATH", os.getenv("BOB_PATH", "")).strip()
+if bob_path: configs["BOB_SHELL_PATH"] = bob_path
+
+print(json.dumps({"configs": configs}))
+PYEOF
+)
+
+    # Nothing to push
+    local has_config
+    has_config=$(python3 -c "
+import json, sys
+print('true' if json.loads(sys.argv[1]).get('configs') else 'false')
+" "$payload")
+
+    if [[ "$has_config" != "true" ]]; then
+        write_to_log_file "INFO" "No LLM provider configured — Causa Backend will use heuristic RCA"
+        log_validation_success "Causa Backend LLM config (skipped — no provider set in llm.env)"
+        return 0
+    fi
+
+    write_to_log_file "INFO" "Pushing LLM config (provider: ${LLM_PROVIDER:-}, model: ${LLM_MODEL_NAME:-})"
+
+    local causa_pod
+    causa_pod=$(kubectl get pods \
+        -l "app=causa-backend" \
+        -n "$namespace" \
+        --field-selector="status.phase=Running" \
+        -o "jsonpath={.items[0].metadata.name}" \
+        2>>"${LOG_FILE}" || true)
+
+    if [[ -z "$causa_pod" ]]; then
+        write_to_log_file "WARN" "Causa Backend pod not running — skipping config push (RCA will run without LLM)"
+        return 0
+    fi
+
+    start_spinner "Pushing config to Causa Backend (up to 5 attempts)..."
+    local cfg_rc=1 attempt
+    for attempt in 1 2 3 4 5; do
+        cfg_rc=0
+        kubectl exec -n "$namespace" "$causa_pod" -- \
+            curl -sf --max-time 10 \
+            -X POST "http://localhost:8080/api/v1/configs" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            >>"${LOG_FILE}" 2>&1 || cfg_rc=$?
+        [[ $cfg_rc -eq 0 ]] && break
+        write_to_log_file "INFO" "Config push attempt ${attempt}/5 failed (rc=${cfg_rc}) — retrying in 10s..."
+        [[ $attempt -lt 5 ]] && sleep 10
+    done
+    stop_spinner
+
+    if [[ $cfg_rc -eq 0 ]]; then
+        log_install_success "Causa Backend configured (LLM config pushed)"
+    else
+        log_file_only "Config push failed after 5 attempts (non-fatal — RCA will run without LLM)"
+        log_validation_success "Causa config push (failed — check ${LOG_FILE})"
+    fi
+}
+
+export -f validate_llm_config
+export -f create_llm_secrets
+export -f configure_llm_runtime

--- a/quarkus-rca/lib/uninstall.sh
+++ b/quarkus-rca/lib/uninstall.sh
@@ -53,6 +53,7 @@ terminate_demo() {
     local namespace="$1"
     local demo_dir="$2"
     local skip_installer="${3:-false}"
+    local delete_cluster="${4:-false}"
 
     if [[ -z "$namespace" || -z "$demo_dir" ]]; then
         log_error "terminate_demo requires namespace and demo_dir"
@@ -61,56 +62,101 @@ terminate_demo() {
 
     log_file_only "TERMINATE MODE — namespace: $namespace"
 
-    # ── Step 1: Run installer teardown via install.sh --terminate ────────────
-    # The installer script is named install.sh on the quarkus-rca branch.
-    if [[ "$skip_installer" == "false" ]]; then
-        log_section "Running installer cleanup (install.sh --terminate)"
-        local installer_script="$demo_dir/installer/install.sh"
-        if [[ -f "$installer_script" ]]; then
-            log_file_only "Running: bash $installer_script --terminate -n $namespace"
-            start_spinner "Running install.sh --terminate..."
-            bash "$installer_script" --terminate -n "$namespace" 2>&1 \
-                | sed 's/\x1b\[[0-9;]*m//g' >>"$LOG_FILE"
-            local rc=${PIPESTATUS[0]}
-            stop_spinner
-            if [[ $rc -eq 0 ]]; then
-                log_install_success "Installer cleanup"
-            else
-                log_file_only "Installer cleanup encountered issues — check log: $LOG_FILE"
-            fi
-        else
-            log_file_only "Installer script not found: $installer_script — skipping"
-            log_validation_success "Installer cleanup (skipped — script not found)"
-        fi
-    else
-        log_file_only "Installer cleanup skipped (--skip-installer)"
-    fi
-
-    # ── Step 2: Delete quarkus-perf workload + load-gen ──────────────────────
+    # ── Step 1: Delete quarkus-perf workload + load-gen ──────────────────────
+    # Done FIRST, before the installer teardown, while the cluster is still
+    # fully operational and the namespace is guaranteed to exist.
     log_section "Deleting quarkus-perf workload"
 
-    # Use the rendered manifest written by demo.sh during install; the raw
-    # chaos-lab clone is deleted in Step 3 and is not available here.
     if check_namespace "$namespace"; then
-        # Delete load-gen job first (Jobs are immutable; delete by name)
+        # Delete load-gen job by name (Jobs are immutable).
         start_spinner "Deleting load-gen job..."
         kubectl delete job quarkus-perf-load-gen -n "$namespace" \
             --ignore-not-found=true >>"$LOG_FILE" 2>&1 || true
         stop_spinner
         log_install_success "load-gen job deleted"
 
-        # Delete workload — spinner wraps the actual kubectl delete work
+        # Prefer the rendered manifest produced at install time; fall back to
+        # a direct label-selector delete so cleanup works even when the
+        # artifacts directory is missing (e.g. first -t run on a fresh clone).
         local workload_manifest="$demo_dir/quarkus-perf-deploy.rendered.yaml"
         start_spinner "Deleting quarkus-perf deployment..."
-        delete_manifest "$workload_manifest" "$namespace"
-        local _delete_rc=$?
+        if [[ -f "$workload_manifest" ]]; then
+            log_file_only "Deleting quarkus-perf via manifest: $workload_manifest"
+            kubectl delete -f "$workload_manifest" -n "$namespace" \
+                --ignore-not-found=true >>"$LOG_FILE" 2>&1
+            local _delete_rc=$?
+        else
+            log_file_only "Rendered manifest not found — deleting quarkus-perf by label selector"
+            kubectl delete all -n "$namespace" \
+                -l "app=${WORKLOAD_APP_NAME}" \
+                --ignore-not-found=true >>"$LOG_FILE" 2>&1
+            local _delete_rc=$?
+        fi
         stop_spinner
-        # log_install_success / log_error already emitted by delete_manifest;
-        # stop_spinner is unconditional so it always clears the terminal line.
-        [[ $_delete_rc -ne 0 ]] && log_file_only "Workload deletion failed — continuing cleanup"
+        if [[ $_delete_rc -eq 0 ]]; then
+            log_install_success "quarkus-perf workload deleted"
+        else
+            log_file_only "quarkus-perf deletion encountered issues (rc=$_delete_rc) — continuing cleanup"
+        fi
     else
         log_file_only "Namespace $namespace not found — skipping workload deletion"
         log_validation_success "quarkus-perf cleanup (skipped — namespace not found)"
+    fi
+
+    # ── Step 2: Run installer teardown via install.sh --terminate ────────────
+    # Runs AFTER the workload is deleted so the cluster is still up during
+    # Step 1. install.sh --terminate removes the Causa stack components.
+    # Pass --delete-cluster to also tear down the Kind cluster.
+    if [[ "$skip_installer" == "false" ]]; then
+        log_section "Running installer cleanup (install.sh --terminate)"
+        local installer_script="$demo_dir/installer/install.sh"
+        if [[ -f "$installer_script" ]]; then
+            local _installer_log
+            _installer_log="$(dirname "$installer_script")/install.log"
+
+            local _terminate_args=(--terminate -n "$namespace")
+            [[ "$delete_cluster" == "true" ]] && _terminate_args+=(--delete-cluster)
+
+            log_file_only "Running: /usr/bin/env bash $installer_script ${_terminate_args[*]}"
+
+            {
+                echo ""
+                echo -e "\033[0;36m\033[1mFull installer log: $_installer_log\033[0m"
+                echo ""
+            } >/dev/tty 2>/dev/null || true
+
+            # Same fifo split as the install path: log gets everything unfiltered,
+            # terminal sees only the clean lines (structured log lines stripped).
+            local _t_fifo
+            _t_fifo=$(mktemp -t demo_uninstall_fifo.XXXXXX)
+            rm -f "$_t_fifo"
+            mkfifo "$_t_fifo"
+            grep -v -E '^\[20[0-9]{2}-[0-9]{2}-[0-9]{2}T|^\[(INFO|SUCCESS|SECTION|WARN|ERROR|DEBUG)\]' \
+                < "$_t_fifo" >/dev/tty 2>/dev/null &
+            local _t_fifo_pid=$!
+
+            /usr/bin/env bash "$installer_script" "${_terminate_args[@]}" \
+                2>&1 | tee -a "$LOG_FILE" > "$_t_fifo"
+            local rc=${PIPESTATUS[0]}
+
+            wait "$_t_fifo_pid" 2>/dev/null || true
+            rm -f "$_t_fifo"
+
+            if [[ $rc -eq 0 ]]; then
+                log_install_success "Installer cleanup"
+            else
+                log_file_only "Installer cleanup encountered issues (rc=$rc) — check log: $LOG_FILE"
+                log_validation_success "Installer cleanup (check log for details)"
+            fi
+        else
+            log_error "Installer script not found at: $installer_script"
+            log_error "  Re-run without -t first to clone the installer, or run install.sh --terminate manually:"
+            log_error "  bash artifacts/installer/install.sh --terminate -n $namespace"
+            log_validation_success "Installer cleanup (skipped — script not found; see above)"
+        fi
+    else
+        log_file_only "Installer cleanup skipped (--skip-installer)"
+        log_validation_success "Installer cleanup (skipped — --skip-installer)"
     fi
 
     # ── Step 3: Remove cloned repos / artifacts ───────────────────────────────

--- a/quarkus-rca/llm.env.example
+++ b/quarkus-rca/llm.env.example
@@ -70,7 +70,6 @@ GOOGLE_APPLICATION_CREDENTIALS=./causa-gcp-key.json
 
 # LLM_PROVIDER=bob
 # LLM_API_KEY=your-bob-api-key   # Required if Bob requires API key authentication
-# BOB_PATH=bob                  # Optional: custom path to bob binary (default: bob)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for Application Default Credentials (ADC) bas64 JSON encoded LLM configuration via configAPI

## Summary by Sourcery

Configure LLM credentials securely across the demo deployment while improving MCP registration and teardown behavior.

New Features:
- Add provider-aware LLM configuration for Vertex AI, Anthropic, and Bob, including credential validation and Kubernetes secret provisioning.
- Post Vertex AI ADC credentials as base64-encoded JSON through the backend configuration API.
- Support IDE-specific MCP configuration for Bob and other supported IDEs, including automatic cleanup of stale entries.

Bug Fixes:
- Ensure LLM credentials are available during backend startup and configuration, preventing failures caused by posting raw or unavailable credential files.
- Improve demo teardown reliability by removing workloads before installer cleanup and optionally deleting the Kind cluster.

Enhancements:
- Refactor LLM setup into reusable validation, secret creation, and runtime configuration helpers with clearer error handling and retries.

Deployment:
- Provision and mount provider credentials as Kubernetes secrets for backend runtime use.

Documentation:
- Update demo usage and configuration guidance for LLM setup, MCP registration, and optional Kind cluster deletion.

Chores:
- Add LLM helper library and integrate it into the Quarkus RCA demo lifecycle.